### PR TITLE
refactor: update package imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,5 +9,4 @@ Description: More about what it does (maybe more than one line)
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
-Depends: httr, data.table
-Imports: httr, data.table
+Imports: httr, data.table, jsonlite

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,3 @@
 exportPattern("^[[:alpha:]]+")
 import(data.table)
+import(httr)

--- a/R/FPLGetCurrentGW.R
+++ b/R/FPLGetCurrentGW.R
@@ -1,6 +1,6 @@
 FPLGetCurrentGW <- function() {
 
-  resp <- httr::GET("https://fantasy.premierleague.com/api/bootstrap-static/")
+  resp <- GET("https://fantasy.premierleague.com/api/bootstrap-static/")
   stop_for_status(resp)
 
   dat <- jsonlite::fromJSON(content(resp, "text", encoding = "UTF-8"), flatten = TRUE)

--- a/R/FPLGetPointsForWeek.R
+++ b/R/FPLGetPointsForWeek.R
@@ -1,5 +1,6 @@
 FPLGetPointsForWeek <- function(GW){
   x <- GET(paste0("https://fantasy.premierleague.com/api/event/",GW,"/live/"))
+  stop_for_status(x)
 
   y <- content(x)
   ListOfData <- lapply(X = y$elements, function(x){data.table(id = x$id,Points = x$stats$total_points)})

--- a/R/FPLGetTransfers.R
+++ b/R/FPLGetTransfers.R
@@ -6,6 +6,7 @@ FPLGetTransfers <- function(LeagueCode, GW){
 
   TransfersList  <- lapply(X = EntriesToLoop,FUN = function(x){
     x <- GET(url = paste0("https://fantasy.premierleague.com/api/entry/",x,"/transfers"))
+    stop_for_status(x)
 
     y <- content(x)
     Output <- rbindlist(y)


### PR DESCRIPTION
## Summary
- move httr and jsonlite to Imports and drop Depends
- import httr so functions like GET and content can be called unqualified
- clean up FPLGetCurrentGW to use httr via the new import
- check HTTP status in FPLGetPointsForWeek and FPLGetTransfers

## Testing
- `R CMD check .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac322644448332913cf55a0892c28f