### PR TITLE
Add generic modal XI comparison with world and league wrappers

### DIFF
--- a/R/FPLFindClosestToLeagueModal.R
+++ b/R/FPLFindClosestToLeagueModal.R
@@ -1,21 +1,12 @@
 #' Compare league teams to the league modal XI
 #'
+#' Convenience wrapper around `FPLFindClosestToModalXI` using the
+#' league modal XI supplier.
+#'
 #' @param LeagueCode League code to query.
 #' @param GW Gameweek number.
 #'
 #' @return A data.table with similarity scores to the league's modal XI.
 FPLFindClosestToLeagueModal <- function(LeagueCode, GW){
-  ModalLeague <- FPLGetLeagueModalXI(LeagueCode, GW)$PlayerId
-  LeagueInfo <- FPLGetLeagueInfo(LeagueCode)
-  setnames(LeagueInfo, "player_name", "PlayerName")
-  PlayerIds <- LeagueInfo$PlayerId
-  names(PlayerIds) <- LeagueInfo$PlayerName
-  Teams <- lapply(PlayerIds, FPLGetUserTeam, GW = GW)
-  Sims <- rbindlist(lapply(names(Teams), function(Nm){
-    Team <- Teams[[Nm]][Status == "Selected", element]
-    data.table(Manager = Nm,
-               Sim = FPLCompareTeams(Team, ModalLeague))
-  }))
-  setorder(Sims, -Sim)
-  return(Sims)
+  FPLFindClosestToModalXI(LeagueCode, GW, FPLGetLeagueModalXI)
 }

--- a/R/FPLFindClosestToModalXI.R
+++ b/R/FPLFindClosestToModalXI.R
@@ -1,0 +1,26 @@
+#' Compare league teams to a supplied modal XI
+#'
+#' @param LeagueCode League code to query.
+#' @param GW Gameweek number.
+#' @param modal_fun Function returning a data.table with a PlayerId column.
+#'
+#' @return A data.table with similarity scores to the modal XI.
+FPLFindClosestToModalXI <- function(LeagueCode, GW, modal_fun){
+  args <- list(GW = GW)
+  if ("LeagueCode" %in% names(formals(modal_fun))) {
+    args$LeagueCode <- LeagueCode
+  }
+  ModalXI <- do.call(modal_fun, args)$PlayerId
+  LeagueInfo <- FPLGetLeagueInfo(LeagueCode)
+  setnames(LeagueInfo, "player_name", "PlayerName")
+  PlayerIds <- LeagueInfo$PlayerId
+  names(PlayerIds) <- LeagueInfo$PlayerName
+  Teams <- lapply(PlayerIds, FPLGetUserTeam, GW = GW)
+  Sims <- rbindlist(lapply(names(Teams), function(Nm){
+    Team <- Teams[[Nm]][Status == "Selected", element]
+    data.table(Manager = Nm,
+               Sim = FPLCompareTeams(Team, ModalXI))
+  }))
+  setorder(Sims, -Sim)
+  return(Sims)
+}

--- a/R/FPLFindClosestToWorldModal.R
+++ b/R/FPLFindClosestToWorldModal.R
@@ -1,21 +1,12 @@
 #' Compare league teams to the world modal XI
 #'
+#' Convenience wrapper around `FPLFindClosestToModalXI` using the
+#' world modal XI supplier.
+#'
 #' @param LeagueCode League code to query.
 #' @param GW Gameweek number.
 #'
 #' @return A data.table with similarity scores to the world modal XI.
 FPLFindClosestToWorldModal <- function(LeagueCode, GW){
-  ModalWorld <- FPLGetModalXIWorld(GW)$PlayerId
-  LeagueInfo <- FPLGetLeagueInfo(LeagueCode)
-  setnames(LeagueInfo, "player_name", "PlayerName")
-  PlayerIds <- LeagueInfo$PlayerId
-  names(PlayerIds) <- LeagueInfo$PlayerName
-  Teams <- lapply(PlayerIds, FPLGetUserTeam, GW = GW)
-  Sims <- rbindlist(lapply(names(Teams), function(Nm){
-    Team <- Teams[[Nm]][Status == "Selected", element]
-    data.table(Manager = Nm,
-               Sim = FPLCompareTeams(Team, ModalWorld))
-  }))
-  setorder(Sims, -Sim)
-  return(Sims)
+  FPLFindClosestToModalXI(LeagueCode, GW, FPLGetModalXIWorld)
 }


### PR DESCRIPTION
## Summary
- add convenience wrappers `FPLFindClosestToWorldModal` and `FPLFindClosestToLeagueModal`
- update runtime example to showcase wrapper usage

## Testing
- ❌ `R -q -e "devtools::check()"` (R not installed)


------
https://chatgpt.com/codex/tasks/task_e_68ac56cc8b1483328eba384e2cc06e3b