### PR TITLE
Generalize modal XI points calculation

### DIFF
--- a/R/FPLGetLeagueModalTeamPoints.R
+++ b/R/FPLGetLeagueModalTeamPoints.R
@@ -1,0 +1,19 @@
+#' Points for the league modal XI across multiple gameweeks
+#'
+#' For each gameweek in the provided range, computes the league modal XI and
+#' totals the points scored by that XI.
+#'
+#' @param LeagueCode League code to query.
+#' @param GWs Vector of gameweek numbers. Defaults to all completed gameweeks.
+#'
+#' @return A data.table with the points scored by the league modal XI for each
+#'   gameweek and a cumulative tally.
+FPLGetLeagueModalTeamPoints <- function(LeagueCode,
+                                        GWs = seq_len(FPLGetCurrentGW()$current)){
+  Results <- lapply(GWs, function(gw){
+    data.table(GW = gw, Points = FPLGetLeagueXIPoints(LeagueCode, gw))
+  })
+  out <- rbindlist(Results)
+  out[, CumulativePoints := cumsum(Points)]
+  return(out)
+}

--- a/R/FPLGetLeagueXIPoints.R
+++ b/R/FPLGetLeagueXIPoints.R
@@ -1,38 +1,15 @@
 #' Points scored by the league modal XI in a gameweek
 #'
-#' Calculates the total points obtained by a league's modal XI for a specified
-#' gameweek. The modal XI is determined using `FPLGetLeagueModalXI`, which
-#' enforces basic formation rules.
+#' Wrapper around `.FPLGetModalXIPoints` using `FPLGetLeagueModalXI` to supply the
+#' league modal XI.
 #'
 #' @param LeagueCode League code to query.
 #' @param GW Gameweek number.
 #'
 #' @return Total points scored by the league modal XI in the gameweek.
 FPLGetLeagueXIPoints <- function(LeagueCode, GW){
-  XI <- FPLGetLeagueModalXI(LeagueCode, GW)[, .(PlayerId)]
-  Points <- FPLGetGameweekPoints(GW)[, .(PlayerId = id, Points)]
-  XI[Points, on = "PlayerId", Points := i.Points]
-  XI[is.na(Points), Points := 0]
-  return(sum(XI$Points))
-}
-
-#' Points for the league modal XI across multiple gameweeks
-#'
-#' For each gameweek in the provided range, computes the league modal XI and
-#' totals the points scored by that XI.
-#'
-#' @param LeagueCode League code to query.
-#' @param GWs Vector of gameweek numbers. Defaults to all completed gameweeks.
-#'
-#' @return A data.table with the points scored by the league modal XI for each
-#'   gameweek and a cumulative tally.
-FPLGetLeagueModalTeamPoints <- function(LeagueCode,
-                                        GWs = seq_len(FPLGetCurrentGW()$current)){
-  Results <- lapply(GWs, function(gw){
-    data.table(GW = gw, Points = FPLGetLeagueXIPoints(LeagueCode, gw))
-  })
-  out <- rbindlist(Results)
-  out[, CumulativePoints := cumsum(Points)]
-  return(out)
+  .FPLGetModalXIPoints(GW = GW,
+                       modal_fun = FPLGetLeagueModalXI,
+                       LeagueCode = LeagueCode)
 }
 

--- a/R/FPLGetWorldXIPoints.R
+++ b/R/FPLGetWorldXIPoints.R
@@ -1,17 +1,12 @@
 #' Points scored by the world modal XI in a gameweek
 #'
-#' Calculates the total points obtained by the world modal XI for a
-#' specified gameweek. The world modal XI is determined using global
-#' selection percentages and adheres to basic squad rules.
+#' Wrapper around `.FPLGetModalXIPoints` using `FPLGetModalXIWorld` to supply the
+#' global modal XI.
 #'
 #' @param GW Gameweek number.
 #'
 #' @return Total points scored by the world modal XI in the gameweek.
 FPLGetWorldXIPoints <- function(GW){
-  XI <- FPLGetModalXIWorld(GW)[, .(PlayerId, WebName)]
-  Points <- FPLGetGameweekPoints(GW)[, .(PlayerId = id, Points)]
-  XI[Points, on = "PlayerId", Points := i.Points]
-  XI[is.na(Points), Points := 0]
-  return(sum(XI$Points))
+  .FPLGetModalXIPoints(GW = GW, modal_fun = FPLGetModalXIWorld)
 }
 

--- a/R/internal-FPLGetModalXIPoints.R
+++ b/R/internal-FPLGetModalXIPoints.R
@@ -1,0 +1,23 @@
+#' Points scored by a modal XI in a gameweek
+#'
+#' Calculates the total points obtained by a modal XI for a specified
+#' gameweek. The modal XI is supplied by the user via a function that
+#' determines the squad to evaluate.
+#'
+#' @param GW Gameweek number.
+#' @param modal_fun Function that returns a data.table describing the modal XI.
+#'   It must accept a `GW` argument and may take additional parameters passed
+#'   through `...`.
+#' @param ... Additional arguments forwarded to `modal_fun`.
+#'
+#' @return Total points scored by the modal XI in the gameweek.
+#' @noRd
+.FPLGetModalXIPoints <- function(GW, modal_fun, ...){
+  XI <- modal_fun(GW = GW, ...)
+  XI <- XI[, .(PlayerId)]
+  Points <- FPLGetGameweekPoints(GW)[, .(PlayerId = id, Points)]
+  XI[Points, on = "PlayerId", Points := i.Points]
+  XI[is.na(Points), Points := 0]
+  return(sum(XI$Points))
+}
+


### PR DESCRIPTION
## Summary
- Convert modal XI points helper into internal `.FPLGetModalXIPoints`
- Update world and league point wrappers to use the internal helper
- Separate `FPLGetLeagueModalTeamPoints` into its own file

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for ubuntu archives)*

------
https://chatgpt.com/codex/tasks/task_e_68ac56d5515883328f9eb5f97f43085c