### PR TITLE
Add unit tests for FPLGetCurrentGW

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,5 @@ License: What license is it under?
 Encoding: UTF-8
 LazyData: true
 Imports: httr, data.table, jsonlite
+Suggests: testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(THFPL)
+
+test_check("THFPL")

--- a/tests/testthat/test-FPLGetCurrentGW.R
+++ b/tests/testthat/test-FPLGetCurrentGW.R
@@ -1,0 +1,20 @@
+library(testthat)
+
+# This test makes a live call to the FPL API. It verifies that the
+# structure of the returned gameweek information is valid.
+test_that("FPLGetCurrentGW retrieves gameweek numbers from the API", {
+  res <- FPLGetCurrentGW()
+
+  expect_named(res, c("current", "next", "finished"))
+
+  expect_true(is.numeric(res$current) && length(res$current) == 1)
+  expect_true(is.numeric(res$finished) && length(res$finished) == 1)
+
+  expect_true(is.numeric(res$next))
+  expect_true(length(res$next) <= 1)
+
+  expect_true(res$finished <= res$current)
+  if (length(res$next) == 1) {
+    expect_true(res$next >= res$current)
+  }
+})


### PR DESCRIPTION
## Summary
- add testthat infrastructure
- add unit tests for `FPLGetCurrentGW` using live API
- declare testthat in DESCRIPTION

## Testing
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `apt-get install -y r-base` *(fails: Unable to locate package r-base)*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e203cac0833296e822ab84b8af73